### PR TITLE
Fixing String sent to exec command

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,12 +7,12 @@ function getCmd() {
     var arch = process.arch.match(/64/) ? '64' : '32';
 
     switch (process.platform) {
-    case 'darwin':
-        return '"' + path.join(__dirname, '/lib/osx64/mediainfo') + '"';
-    case 'win32':
-        return '"' + path.join(__dirname, '/lib/win32/mediainfo.exe') + '"';
-    case 'linux':
-        return 'LD_LIBRARY_PATH="' + path.join(__dirname, '/lib/linux' + arch) + '" "' + path.join(__dirname, '/lib/linux' + arch, '/mediainfo') + '"';
+        case 'darwin':
+            return safeLocalPath(path.join(__dirname, '/lib/osx64/mediainfo'));
+        case 'win32':
+            return safeLocalPath(path.join(__dirname, '/lib/win32/mediainfo.exe'));
+        case 'linux':
+            return "LD_LIBRARY_PATH=" + safeLocalPath(path.join(__dirname, '/lib/linux' + arch)) + " " + safeLocalPath(path.join(__dirname, '/lib/linux' + arch, '/mediainfo'));
     }
 }
 
@@ -83,6 +83,15 @@ function buildJson(xml) {
     });
 }
 
+/*
+ Convert local file path to a more safe path for shell exec command use
+ */
+function safeLocalPath(path) {
+    path = path.replace(/'/g, "'\"'\"'"); // escape single qoute
+    path = "'" + path + "'";// wrap with single qoutes
+    return path;
+}
+
 module.exports = function MediaInfo() {
     var args = [].slice.call(arguments);
     var cmd_options = typeof args[0] === "object" ? args.shift() : {};
@@ -93,7 +102,7 @@ module.exports = function MediaInfo() {
     Array.prototype.slice.apply(args).forEach(function (val, idx) {
         var files = glob.sync(val, {cwd: (cmd_options.cwd || process.cwd()), nonull: true});
         for (var i in files) {
-            cmd.push('"' + files[i] + '"'); // files
+            cmd.push(safeLocalPath(files[i])); // files
         }
     });
 


### PR DESCRIPTION
after testing your module with several files i have found that if the file name has certain special characters in it is name it will fail and throwing this error: 

Command failed: "/Users/Me/WebstormProjects/pro-media/node_modules/mediainfo-wrapper/lib/osx64/mediainfo" --Output=XML --Full "/Users/Me/Desktop/Test Contents/Files Kinds/AVI(16개)/30-02-102_가나다동해물과백두산_LKWQIOFJLdlksadk_@!#@!$#@&_大姜孔民.avi  

to fix this  i have created safeLocalPath that handle this fix by escaping single quote in file name using '"'"' then wrap the file name with single quote, for more information check these 2 stackoverflow answers: 
1- http://stackoverflow.com/a/11233902/427622
2- http://stackoverflow.com/a/1250279/427622
